### PR TITLE
Revert "Bump sphinx from 4.5.0 to 5.0.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ crabnet==2.0.2
 conda-souschef==2.1.2
 scikit-learn==1.1.1
 myst-parser==0.17.2
-sphinx==5.0.1
+sphinx==4.5.0
 sphinx_rtd_theme==1.0.0
 sphinx_copybutton==0.5.0
 composition-based-feature-vector==1.0.4


### PR DESCRIPTION
Reverts sparks-baird/mat_discover#79

RTD: 

> The conflict is caused by:
>     The user requested sphinx==5.0.1
>     myst-parser 0.17.2 depends on sphinx<5 and >=3.1
> 
> To fix this you could try to:
> 1. loosen the range of package versions you've specified
> 2. remove package versions to allow pip attempt to solve the dependency conflict

https://readthedocs.org/projects/mat-discover/builds/17154609/