### PR TITLE
fix: change the default behavior of overriding kwarg dicts for UMAP and HDBSCAN

### DIFF
--- a/.github/workflows/conda-build-pytest.yml
+++ b/.github/workflows/conda-build-pytest.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install dependencies
       shell: bash -l {0}
       run: |
-        conda install git conda-build conda-verify anaconda-client conda-forge::grayskull conda-forge::conda-souschef conda-forge::flit conda-forge::coveralls conda-forge::conda-souschef sgbaird::pqdm sgbaird::elmd
+        conda install git pytest conda-build conda-verify anaconda-client conda-forge::grayskull conda-forge::conda-souschef conda-forge::flit conda-forge::coveralls conda-forge::conda-souschef sgbaird::pqdm sgbaird::elmd
         pip install ElM2D==0.4.1
         
     - name: Miniconda build


### PR DESCRIPTION
densmap=True, output_dens=True, low_memory=True, and dens_lambda=self.dens_lambda

To avoid the following error:
```python
AttributeError                            Traceback (most recent call last)
[<ipython-input-4-cc761643aed5>](https://localhost:8080/#) in <module>()
----> 1 get_ipython().run_cell_magic('time', '', 'score = disc.predict(val_df, umap_random_state=42)')

4 frames
[/usr/local/lib/python3.7/dist-packages/IPython/core/interactiveshell.py](https://localhost:8080/#) in run_cell_magic(self, magic_name, line, cell)
   2115             magic_arg_s = self.var_expand(line, stack_depth)
   2116             with self.builtin_trap:
-> 2117                 result = fn(magic_arg_s, cell)
   2118             return result
   2119 

<decorator-gen-53> in time(self, line, cell, local_ns)

[/usr/local/lib/python3.7/dist-packages/IPython/core/magic.py](https://localhost:8080/#) in <lambda>(f, *a, **k)
    186     # but it's overkill for just that one bit of state.
    187     def magic_deco(arg):
--> 188         call = lambda f, *a, **k: f(*a, **k)
    189 
    190         if callable(arg):

[/usr/local/lib/python3.7/dist-packages/IPython/core/magics/execution.py](https://localhost:8080/#) in time(self, line, cell, local_ns)
   1191         else:
   1192             st = clock2()
-> 1193             exec(code, glob, local_ns)
   1194             end = clock2()
   1195             out = None

<timed exec> in <module>()

[/usr/local/lib/python3.7/dist-packages/mat_discover/mat_discover_.py](https://localhost:8080/#) in predict(self, val_df, plotting, umap_random_state, pred_weight, proxy_weight, dummy_run, count_repeats, return_peak)
    588                     )
    589                     self.umap_emb, self.umap_r_orig = self.extract_emb_rad(
--> 590                         self.umap_trans
    591                     )[:2]
    592                     self.std_emb, self.std_r_orig = self.extract_emb_rad(

[/usr/local/lib/python3.7/dist-packages/mat_discover/mat_discover_.py](https://localhost:8080/#) in extract_emb_rad(self, trans)
   1242         """
   1243         emb, r_orig_log, r_emb_log = attrgetter("embedding_", "rad_orig_", "rad_emb_")(
-> 1244             trans
   1245         )
   1246         r_orig = np.exp(r_orig_log)

AttributeError: 'UMAP' object has no attribute 'rad_orig_'
```

Also:
default min_cluster_size = 50, min_samples=1, cluster_selection_epsilon=0.63 (but only if not overriden)